### PR TITLE
Add Memory Growth Differ error in Multi-GPU

### DIFF
--- a/object_tracker.py
+++ b/object_tracker.py
@@ -5,6 +5,7 @@ import time
 import tensorflow as tf
 physical_devices = tf.config.experimental.list_physical_devices('GPU')
 if len(physical_devices) > 0:
+    tf.config.experimental.set_visible_devices(physical_devices[0], 'GPU')
     tf.config.experimental.set_memory_growth(physical_devices[0], True)
 from absl import app, flags, logging
 from absl.flags import FLAGS


### PR DESCRIPTION
In Multi-GPUs environment, previous code occur `ValueError: Memory growth cannot differ between GPU devices` in `object_tracker.py` file.

**- Previous `object_tracker.py`**

```python
physical_devices = tf.config.experimental.list_physical_devices('GPU')

if len(physical_devices) > 0:
    tf.config.experimental.set_memory_growth(physical_devices[0], True)
```

**-Modified `object_tracker.py` : Line 8**

```python
physical_devices = tf.config.experimental.list_physical_devices('GPU')

if len(physical_devices) > 0:
    tf.config.experimental.set_visible_devices(physical_devices[0], 'GPU')
    tf.config.experimental.set_memory_growth(physical_devices[0], True)
```

<hr>

**Environment**

* OS : Windows10
* Envs : Anaconda
* Python : 3.7.0
* GPU : NVIDIA GeForce RTX 3090 24GB * 2 (Multi-GPU)
* CUDA/cuDNN : 11.1.1/8.1.1

**GPU is :**

```
> nvidia-smi 
Mon Jul 19 16:01:51 2021
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 456.81       Driver Version: 456.81       CUDA Version: 11.1     |
|-------------------------------+----------------------+----------------------+
| GPU  Name            TCC/WDDM | Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  GeForce RTX 3090   WDDM  | 00000000:01:00.0  On |                  N/A |
| 67%   59C    P2   126W / 370W |   2221MiB / 24576MiB |      0%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+
|   1  GeForce RTX 3090   WDDM  | 00000000:02:00.0 Off |                  N/A |
|  0%   32C    P8     7W / 370W |    593MiB / 24576MiB |      0%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+
```
<hr>

**ValueError**

```
Traceback (most recent call last):
  File "object_tracker.py", line 18, in <module>
    from core.yolov4 import filter_boxes
  File "C:\Users\USER\Downloads\yolov4-deepsort-master\yolov4-deepsort-master\core\yolov4.py", line 292, in <module>
    def filter_boxes(box_xywh, scores, score_threshold=0.4, input_shape = tf.constant([416,416])):
  File "C:\Users\USER\AppData\Roaming\Python\Python37\site-packages\tensorflow\python\framework\constant_op.py", line 264, in constant
    allow_broadcast=True)
  File "C:\Users\USER\AppData\Roaming\Python\Python37\site-packages\tensorflow\python\framework\constant_op.py", line 275, in _constant_impl
    return _constant_eager_impl(ctx, value, dtype, shape, verify_shape)
  File "C:\Users\USER\AppData\Roaming\Python\Python37\site-packages\tensorflow\python\framework\constant_op.py", line 300, in _constant_eager_impl
    t = convert_to_eager_tensor(value, ctx, dtype)
  File "C:\Users\USER\AppData\Roaming\Python\Python37\site-packages\tensorflow\python\framework\constant_op.py", line 97, in convert_to_eager_tensor
    ctx.ensure_initialized()
  File "C:\Users\USER\AppData\Roaming\Python\Python37\site-packages\tensorflow\python\eager\context.py", line 524, in ensure_initialized
    config_str = self.config.SerializeToString()
  File "C:\Users\USER\AppData\Roaming\Python\Python37\site-packages\tensorflow\python\eager\context.py", line 986, in config
    gpu_options = self._compute_gpu_options()
  File "C:\Users\USER\AppData\Roaming\Python\Python37\site-packages\tensorflow\python\eager\context.py", line 1045, in _compute_gpu_options
    raise ValueError("Memory growth cannot differ between GPU devices")

ValueError: Memory growth cannot differ between GPU devices
```

See more about tensorflow docs : https://www.tensorflow.org/guide/gpu