### PR TITLE
Update requirements-gpu.txt

### DIFF
--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -1,4 +1,4 @@
-tensorflow-gpu==2.3.0rc0
+tensorflow-gpu==2.6.0
 opencv-python==4.1.1.26
 lxml
 tqdm


### PR DESCRIPTION
changing the version of tensorflow-gpu to 2.6.0 is solving the error problem for version mismatch regarding the error of -----  ImportError: cannot import name 'LayerNormalization' from 'tensorflow.python.keras.layers.normalization'

please update it. I checked it in google colab